### PR TITLE
Removing global ng-cli install

### DIFF
--- a/Dockerfile-Dev
+++ b/Dockerfile-Dev
@@ -5,7 +5,6 @@ WORKDIR /usr/src/app
 # Run install as a separate step for caching
 COPY package*.json ./
 RUN npm install
-RUN npm install -g --no-optional @angular/cli
 
 # Copy everything else
 COPY . .


### PR DESCRIPTION
Currently running this pulls down v6, which expects `angular.json` instead of `.angular-cli.json`, and breaks the build as a result

Pretty sure this line isn't needed though, since it's included as a dependency in package.json